### PR TITLE
Adds optional header params to the fetch methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A common pattern is to destructure the return value, naming only which function 
 
 ### Simple use cases
 #### GET
-```
+```js
 import React, { useState } from 'react'
 import useApi from 'react-use-fetch-api'
 
@@ -29,7 +29,7 @@ export default function InterestingComponent() {
 ```
 
 #### POST
-```
+```js
 import React from 'react'
 import useApi from 'react-use-fetch-api'
 
@@ -39,12 +39,11 @@ export default function InterestingComponent() {
   const onSubmit = () => {
     const newTodo = {
     userId: 1,
-    id: 2,
     title: "Gotta do all the things!",
     completed: false
   }
 
-    post('https://jsonplaceholder.typicode.com/todos', newTodo).then(data => {
+    post('https://jsonplaceholder.typicode.com/todos', {data: newTodo}).then(data => {
       // do something here like redirect the user or show a message or something
     })
   }
@@ -56,7 +55,7 @@ export default function InterestingComponent() {
 ```
 
 #### PUT
-```
+```js
 import React from 'react'
 import useApi from 'react-use-fetch-api'
 
@@ -66,12 +65,11 @@ export default function InterestingComponent() {
   const onSubmit = () => {
     const updatedTodo = {
       userId: 1,
-      id: 2,
       title: "Gotta do all the things!",
       completed: false
     }
     
-    post('https://jsonplaceholder.typicode.com/todos', updatedTodo).then(data => {
+    post('https://jsonplaceholder.typicode.com/todos/1', {data: updatedTodo}).then(data => {
       // do something here like redirect the user or show a message or something
     })
   }
@@ -83,7 +81,7 @@ export default function InterestingComponent() {
 ```
 
 #### DEL
-```
+```js
 import React from 'react'
 import useApi from 'react-use-fetch-api'
 
@@ -102,6 +100,31 @@ export default function InterestingComponent() {
 }
 ```
 
+### Custom headers
+
+All functions accept `data` and `headers` as optional parameters.  If you don't pass custom headers, the default will be:
+
+```js
+{
+  "Content-Type": "application/json",
+  Accept: "application/json"
+}
+```
+
+To use custom headers:
+```js
+const customHeaders = {"Content-Language": "de-DE"}
+
+get('https://jsonplaceholder.typicode.com/todos/1', {headers: customHeaders})
+
+post('https://jsonplaceholder.typicode.com/todos/1', {data: newTodo, headers: customHeaders})
+
+put('https://jsonplaceholder.typicode.com/todos/1', {data: updatedTodo, headers: customHeaders})
+
+del('https://jsonplaceholder.typicode.com/todos/1', {headers: customHeaders})
+
+```
+
 ### Error handling
 The `useApi` hook also allows you to gracefully handle error states.
 
@@ -111,7 +134,7 @@ If the API response comes back with HTTP status code 401 (Unauthorized), the use
 
 For all other errors, the onError handler will be invoked if provided.
 
-```
+```js
 import React, { useState } from 'react'
 import useApi from 'react-use-fetch-api'
 
@@ -139,7 +162,7 @@ The `useApi` hook can be easily mocked in tests. The following code uses Jest's 
 
 You may want to test or use the return value of the `useApi` hook in an assertion.
 
-```
+```js
 import { mount } from 'enzyme'
 import * as useApiModule from 'react-use-fetch-api'
 // ... other imports as needed
@@ -169,7 +192,7 @@ describe('InterestingComponent', () => {
 
 If you are making a request after the user interacts with the component (button click, form submission, etc), you may want to check that the handler had been called with the expected parameters. 
 
-```
+```js
 import { mount } from 'enzyme'
 import * as useApiModule from 'react-use-fetch-api'
 // ... other imports as needed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export default function InterestingComponent() {
     completed: false
   }
 
-    post('https://jsonplaceholder.typicode.com/todos', {data: newTodo}).then(data => {
+    post('https://jsonplaceholder.typicode.com/todos', newTodo).then(data => {
       // do something here like redirect the user or show a message or something
     })
   }
@@ -69,7 +69,7 @@ export default function InterestingComponent() {
       completed: false
     }
     
-    post('https://jsonplaceholder.typicode.com/todos/1', {data: updatedTodo}).then(data => {
+    post('https://jsonplaceholder.typicode.com/todos/1', updatedTodo).then(data => {
       // do something here like redirect the user or show a message or something
     })
   }
@@ -115,13 +115,27 @@ To use custom headers:
 ```js
 const customHeaders = {"Content-Language": "de-DE"}
 
-get('https://jsonplaceholder.typicode.com/todos/1', {headers: customHeaders})
+get('https://jsonplaceholder.typicode.com/todos/1', customHeaders)
 
-post('https://jsonplaceholder.typicode.com/todos/1', {data: newTodo, headers: customHeaders})
+post('https://jsonplaceholder.typicode.com/todos/1', newTodo, customHeaders)
 
-put('https://jsonplaceholder.typicode.com/todos/1', {data: updatedTodo, headers: customHeaders})
+put('https://jsonplaceholder.typicode.com/todos/1', updatedTodo, customHeaders)
 
-del('https://jsonplaceholder.typicode.com/todos/1', {headers: customHeaders})
+del('https://jsonplaceholder.typicode.com/todos/1', customHeaders)
+
+```
+
+To use custom headers with no data:
+```js
+const customHeaders = {"Content-Language": "de-DE"}
+
+get('https://jsonplaceholder.typicode.com/todos/1', customHeaders)
+
+post('https://jsonplaceholder.typicode.com/todos/1', null, customHeaders)
+
+put('https://jsonplaceholder.typicode.com/todos/1', null, customHeaders)
+
+del('https://jsonplaceholder.typicode.com/todos/1', customHeaders)
 
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ const defaultHeaders = {
   Accept: "application/json"
 }
 
-async function fetchData(url, method, {data, headers}) {
-  const response = await fetch(url, {
+async function fetchData({path, method, data, headers}) {
+  const response = await fetch(path, {
     method: method,
     body: !!data ? JSON.stringify(data) : null,
     headers: !!headers ? headers : defaultHeaders
@@ -42,19 +42,19 @@ export function useApi(onUnauthorized, onError) {
 
   return {
     get: (path, headers) =>
-      fetchData(path, GET, {headers: headers})
+      fetchData({path: path, method: GET, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     post: (path, data, headers) =>
-      fetchData(path, POST, {data: data, headers: headers})
+      fetchData({path: path, method: POST, data: data, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     put: (path, data, headers) =>
-      fetchData(path, PUT, {data: data, headers: headers})
+      fetchData({path: path, method: PUT, data: data, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     del: (path, headers) =>
-      fetchData(path, DEL, {headers: headers})
+      fetchData({path: path, method: DEL, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError)
   };

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,16 @@ const POST = "POST";
 const PUT = "PUT";
 const DEL = "DELETE";
 
-async function fetchData(url, method, data) {
+const defaultHeaders = {
+  "Content-Type": "application/json",
+  Accept: "application/json"
+}
+
+async function fetchData(url, method, data, headers) {
   const response = await fetch(url, {
     method: method,
     body: !!data ? JSON.stringify(data) : null,
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json"
-    }
+    headers: !!headers ? headers : defaultHeaders
   })
     .then(response => {
       if (!response.ok) {
@@ -39,20 +41,20 @@ export function useApi(onUnauthorized, onError) {
   };
 
   return {
-    get: path =>
-      fetchData(path, GET, null)
+    get: (path, headers) =>
+      fetchData(path, GET, null, headers)
         .catch(unauthorizedHandler)
         .catch(onError),
-    post: (path, data) =>
-      fetchData(path, POST, data)
+    post: (path, data, headers) =>
+      fetchData(path, POST, data, headers)
         .catch(unauthorizedHandler)
         .catch(onError),
-    put: (path, data) =>
-      fetchData(path, PUT, data)
+    put: (path, data, headers) =>
+      fetchData(path, PUT, data, headers)
         .catch(unauthorizedHandler)
         .catch(onError),
-    del: path =>
-      fetchData(path, DEL, null)
+    del: (path, headers) =>
+      fetchData(path, DEL, null, headers)
         .catch(unauthorizedHandler)
         .catch(onError)
   };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const defaultHeaders = {
   Accept: "application/json"
 }
 
-async function fetchData(url, method, data, headers) {
+async function fetchData(url, method, {data, headers}) {
   const response = await fetch(url, {
     method: method,
     body: !!data ? JSON.stringify(data) : null,
@@ -42,19 +42,19 @@ export function useApi(onUnauthorized, onError) {
 
   return {
     get: (path, headers) =>
-      fetchData(path, GET, null, headers)
+      fetchData(path, GET, {headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     post: (path, data, headers) =>
-      fetchData(path, POST, data, headers)
+      fetchData(path, POST, {data: data, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     put: (path, data, headers) =>
-      fetchData(path, PUT, data, headers)
+      fetchData(path, PUT, {data: data, headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError),
     del: (path, headers) =>
-      fetchData(path, DEL, null, headers)
+      fetchData(path, DEL, {headers: headers})
         .catch(unauthorizedHandler)
         .catch(onError)
   };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,14 @@
 import { useApi } from "../src/index";
 
-let headers = {
+let defaultHeaders = {
   "Content-Type": "application/json",
   Accept: "application/json"
 };
+
+let customHeaders = {
+  "Content-Language": "de-DE",
+  "Date": "Wed, 21 Oct 2015 07:28:00 GMT"
+}
 
 let url;
 let data;
@@ -45,7 +50,25 @@ describe("useApi", () => {
         expect.objectContaining({
           method: "GET",
           body: null,
-          headers: headers
+          headers: defaultHeaders
+        })
+      );
+
+      process.nextTick(() => {
+        global.fetch.mockClear();
+        done();
+      });
+    });
+    
+    it("calls fetch with the custom headers", async done => {
+      const { get } = useApi();
+      await get(url, customHeaders);
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "GET",
+          body: null,
+          headers: customHeaders
         })
       );
 
@@ -177,7 +200,26 @@ describe("useApi", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify(data),
-          headers: headers
+          headers: defaultHeaders
+        })
+      );
+
+      process.nextTick(() => {
+        global.fetch.mockClear();
+        done();
+      });
+    });
+
+    it("calls fetch with the custom headers", async done => {
+      const { post } = useApi();
+      await post(url, data, customHeaders);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify(data),
+          headers: customHeaders
         })
       );
 
@@ -224,6 +266,7 @@ describe("useApi", () => {
           });
         });
       });
+
     });
 
     describe("when the response is not successful", () => {
@@ -310,7 +353,26 @@ describe("useApi", () => {
         expect.objectContaining({
           method: "PUT",
           body: JSON.stringify(data),
-          headers: headers
+          headers: defaultHeaders
+        })
+      );
+
+      process.nextTick(() => {
+        global.fetch.mockClear();
+        done();
+      });
+    });
+    
+    it("calls fetch with the custom headers", async done => {
+      const { put } = useApi();
+      await put(url, data, customHeaders);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify(data),
+          headers: customHeaders
         })
       );
 
@@ -350,13 +412,14 @@ describe("useApi", () => {
           const { put } = useApi();
           const response = put(url, data);
           expect(response).toEqual(mockJsonPromise);
-
+          
           process.nextTick(() => {
             global.fetch.mockClear();
             done();
           });
         });
       });
+      
     });
 
     describe("when the response is not successful", () => {
@@ -442,7 +505,26 @@ describe("useApi", () => {
         expect.objectContaining({
           method: "DELETE",
           body: null,
-          headers: headers
+          headers: defaultHeaders
+        })
+      );
+
+      process.nextTick(() => {
+        global.fetch.mockClear();
+        done();
+      });
+    });
+
+    it("calls fetch with the custom headers", async done => {
+      const { del } = useApi();
+      await del(url, customHeaders);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "DELETE",
+          body: null,
+          headers: customHeaders
         })
       );
 
@@ -489,6 +571,7 @@ describe("useApi", () => {
           });
         });
       });
+
     });
 
     describe("when the response is not successful", () => {


### PR DESCRIPTION
## 📋 Summary
This adds a headers param to the API calls so we can pass custom headers.  If no headers are passed, it defaults to the Accept and Content-Type `application/json`

## 🧐 Why tho
So we can pass custom headers to our APIs!

## 🤔 Caveats, concerns
This switches the internal calls to destructuring named params because data and headers are optional.  I decided to leave the `useApi` methods with positional parameters because it's closest to the current implementation, but it requires users to use `null` if they're passing headers but no data to `put` or `post`.  This is documented in the README.
